### PR TITLE
Fix optuna n_jobs to 1 for reproducible results

### DIFF
--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -4280,7 +4280,7 @@ def tune_model_supervised(
                 enable_pruning=early_stopping
                 and can_early_stop(pipeline_with_model, True, False, False, param_grid),
                 max_iter=early_stopping_max_iters,
-                n_jobs=n_jobs,
+                n_jobs=1, ## to have reproducible results see: https://github.com/optuna/optuna/issues/2540
                 n_trials=n_iter,
                 random_state=seed,
                 scoring=optimize,


### PR DESCRIPTION
following this issue https://github.com/optuna/optuna/issues/2540

## Related Issue or bug
  - non-reproducible results

#### Describe the changes you've made
Just changed n_jobs to 1 so that results are using the user's random seed.